### PR TITLE
ci: wire self-hosted Turbo remote cache [OUT-457]

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,13 @@
+# Turbo remote cache — enables local dev cache sharing with CI and other machines.
+# Copy this to .envrc and fill in the values from 1Password item
+# `Cloudflare Turborepo Cache` (vault `Dev`):
+#   op://Dev/Cloudflare Turborepo Cache/TURBO_TOKEN
+#   op://Dev/Cloudflare Turborepo Cache/TURBO_REMOTE_CACHE_SIGNATURE_KEY
+# direnv will auto-load .envrc when you cd into this directory.
+#
+# TURBO_TEAM must be exactly `outfitter` — it is the R2 object-key prefix.
+
+export TURBO_API=https://turbo-cache.outfitter.dev
+export TURBO_TEAM=outfitter
+export TURBO_TOKEN=<from 1Password: Cloudflare Turborepo Cache>
+export TURBO_REMOTE_CACHE_SIGNATURE_KEY=<from 1Password: Cloudflare Turborepo Cache>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Turbo remote cache — speeds up CI by sharing build artifacts across runs.
+# Forks: these secrets won't be available, and turbo will fall back to local
+# caching automatically. CI still works, just without cross-run cache hits.
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  TURBO_API: https://turbo-cache.outfitter.dev
+  TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+
+jobs:
+  checks:
+    name: Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+      - run: bun install --frozen-lockfile
+      - run: bun run format:check
+      - run: bun run lint:md
+      - run: bun run typecheck
+      - run: bun run build

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ out/
 .env
 .env.*
 !.env.example
+.envrc*
+!.envrc.example
 
 # vercel
 .vercel/

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
+  "remoteCache": {
+    "signature": true
+  },
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Wires this monorepo to the self-hosted Turbo remote cache already verified on `trails`.

Part of [OUT-457](https://linear.app/outfitter/issue/OUT-457/roll-out-turbo-remote-cache-to-active-outfitter-dev-repos). Sibling PR: [biner#36](https://github.com/outfitter-dev/biner/pull/36).

## Changes

- `turbo.json`: enable `remoteCache.signature`
- `.envrc.example`: document `TURBO_API`, `TURBO_TEAM=outfitter`, and the 1Password refs for token + signature key (no secret values)
- `.gitignore`: ignore `.envrc*` while keeping `.envrc.example`
- `.github/workflows/ci.yml`: first CI workflow, with the four Turbo cache env vars and the same fork-fallback comment as `trails`

`TURBO_TEAM` is hardcoded to `outfitter` in the example. That value is the R2 object-key prefix and must match every repo.

## Local setup

```bash
cp .envrc.example .envrc
# fill TURBO_TOKEN and TURBO_REMOTE_CACHE_SIGNATURE_KEY from
# op://Dev/Cloudflare Turborepo Cache
```

Org secrets `TURBO_TOKEN`, `TURBO_TEAM`, and `TURBO_REMOTE_CACHE_SIGNATURE_KEY` are already set (`visibility: all`). No per-repo secret setup.

## Cache verification

Cache health check (`GET /v8/artifacts/status?slug=outfitter`) returned `{"status":"enabled"}`.

Cold-cache remote hit after `turbo run build --force`, then `mv .turbo/cache /tmp/bak`, then `turbo run build`:

```
• turbo 2.9.18

   • Packages in scope: @outfitter/config, @outfitter/tokens, @outfitter/tsconfig, @outfitter/ui, trails-web
   • Running build in 5 packages
   • Remote caching enabled

@outfitter/tokens:build: cache hit, replaying logs 28b35c311e73b311
trails-web:build: cache hit, replaying logs d0f6771aab50605e

 Tasks:    2 successful, 2 total
Cached:    2 cached, 2 total
  Time:    593ms >>> FULL TURBO
```

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [OUT-457](https://linear.app/outfitter/issue/OUT-457/roll-out-turbo-remote-cache-to-active-outfitter-dev-repos)

<div><a href="https://cursor.com/agents/bc-9aa94a2f-9aec-42b0-943d-a9e33611c77b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9aa94a2f-9aec-42b0-943d-a9e33611c77b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

